### PR TITLE
Support sequence match (=) and mismatch (X) in CIGAR strings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Determine the samblaster build number
-BUILDNUM = 19
+BUILDNUM = 20
 # INTERNAL = TRUE
 
 OBJS = samblaster.o sbhash.o

--- a/samblaster.cpp
+++ b/samblaster.cpp
@@ -622,7 +622,7 @@ void calcOffsets(splitLine_t * line)
     {
         int opLen = parseNextInt(&cigar);
         char opCode = parseNextOpCode(&cigar);
-        if      (opCode == 'M') 
+        if      (opCode == 'M' || opCode == '=' || opCode == 'X')
         { 
             line->raLen += opLen;
             line->qaLen += opLen;


### PR DESCRIPTION
Greg;
Thanks for all the work on samblaster. It's a great tool. This small patch enables use with aligners like SNAP that default to specific match/mismatch flags instead of the general 'M' match or mismatch parameter.
