### PR TITLE
Support for OS X.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Determine the samblaster build number
-BUILDNUM = 20
+BUILDNUM = 21
 # INTERNAL = TRUE
 
 OBJS = samblaster.o sbhash.o


### PR DESCRIPTION
Following changes were made:
a) Incremented the BUILDNUM in the Makefile.
b) Added "<inttypes.h> for proper formatting of UINT64 datatype.
c) Added the function mempcpy if it is not defined (since mempcpy is a GNU extension).
d) "sig_t" is defined in /usr/include/signal.h for BSD variants, so changed the typedef to sgn_t.
e) Changed the printf statements for UINT64 to get rid of compiler warnings.
