### PR TITLE
Avoid buffer length issues when marking long SAM lines

### DIFF
--- a/samblaster.cpp
+++ b/samblaster.cpp
@@ -160,7 +160,7 @@ splitLine_t * makeSplitLine()
 {
     splitLine_t * line = (splitLine_t *)malloc(sizeof(splitLine_t));
     line->bufLen = 0;
-    line->maxBufLen = 1000;
+    line->maxBufLen = 10000;
     line->buffer = (char *)malloc(line->maxBufLen);
     line->numFields = 0;
     line->maxFields = 100;


### PR DESCRIPTION
While testing with hg38, samblaster dies on very long SAM lines from HLA matches with a larger number of alternative matches:
```
samblaster: New buffer length exceeds maximum while changing field value
```
This is a small test case which reproduces the issue (although confusingly, it fails consistently on CentOS 6.6 but not at all on Ubuntu 14.04, both with gcc 4.8.2):

https://s3.amazonaws.com/chapmanb/samblaster/samblaster_hg38_linelength.tar.gz

This fix avoid the issue by increasing the maximum buffer length of the line to accommodate these. My C/C++ is terrible so happy for a review on how this affected memory usage or why it behaves differently on Ubuntu/CentOS.